### PR TITLE
Reflect current state of properties in readme.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -47,11 +47,9 @@ Modify *application-local.properties*
 ----
 # Replace values from registered application at https://github.com/settings/developers
 # See the README for additional detail
-security.oauth2.admin.clientId=Value from Client ID
-security.oauth2.admin.clientSecret=Value from Client Secret
 security.oauth2.main.clientId=Value from Client ID
 security.oauth2.main.clientSecret=Value from Client Secret
-security.oauth2.pivotal-cla.token=A Personal Access Token with public_repo scope
+security.oauth2.pivotal-cla.tokenSecret=A Personal Access Token with public_repo scope
 ----
 
 == Setup ngrok


### PR DESCRIPTION
Remove security.oauth2.admin.\* properties, rename security.oauth2.pivotal-cla.token to security.oauth2.pivotal-cla.tokenSecret.
