### PR TITLE
Introduce a workaround for the CF plugin production deployment.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ buildscript {
 apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'spring-boot'
+apply from: "gradle/workaround.gradle"
 apply from: "gradle/deploy.gradle"
 
 jar {

--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -34,9 +34,25 @@ task deploy(dependsOn: [build]) {
 	// deploy if the secure environment vars are available (i.e. this is not a pull request
 	// from a fork) and we're on a branch intended for production deployment.
 	if (!isTravisBuild || (isDeployableTravisBuild && project.hasProperty(TARGET_SPACE))) {
-		dependsOn 'cfLogin'
 
-		dependsOn 'cfDeploy', 'cfSwapDeployed'
+		dependsOn 'cfDeploy'
+
+		space = project.getProperty(TARGET_SPACE)
+		if(space == PRODUCTION_SPACE || space == STAGING_SPACE) {
+			// only needed when variants are set up.
+			dependsOn 'cfSwapDeployed'
+
+			if(space == PRODUCTION_SPACE) {
+
+				// this is a workaround to get cla.pivotal.io bound
+				// setup dependency graph for workaround
+				dependsOn unmapProductionRouteFromInactive
+				cfDeploy.mustRunAfter unmapProductionRouteFromInactive
+				dependsOn 'unmapProductionRouteFromInactive', 'mapProductionRouteToActive'
+				mapProductionRouteToActive.mustRunAfter cfSwapDeployed
+			}
+		}
+
 	} else {
 		onlyIf { false }
 	}
@@ -145,7 +161,7 @@ if (project.hasProperty(TARGET_SPACE)) {
 	}
 
 	cloudfoundry {
-		uris = (space == PRODUCTION_SPACE ? ["pivotal-cla.cfapps.io"] : ["pivotal-cla-${space}.cfapps.io"])
+		uris = ["pivotal-cla-${space}.cfapps.io"]
 	}
 
 	if (space == PRODUCTION_SPACE || space == STAGING_SPACE) {

--- a/gradle/workaround.gradle
+++ b/gradle/workaround.gradle
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.cloudfoundry.client.lib.domain.CloudApplication
+
+buildscript {
+	repositories {
+		mavenCentral()
+	}
+	dependencies {
+		classpath('org.cloudfoundry:cf-gradle-plugin:1.1.2')
+	}
+}
+
+def final PRODUCTION_ROUTE = 'cla.pivotal.io'
+apply plugin: 'cloudfoundry'
+
+
+def final APPLICATION_NAME = 'pivotal-cla'
+/**
+ * Don't look below here otherwise your eyes will hurt.
+ *
+ * For all other feeling adventurous:
+ *
+ * Maps the production route to the active instance. This code is mostly
+ * copy-pasted from the CF plugin. The reason is that the pivotal.io domain
+ * is not listed when querying /v2/spaces/{spaceId}/domains?inline-relations-depth=1.
+ * So the trick here is to obtain domains from /v2/domains?inline-relations-depth=1 and
+ * hope we don't break anything in the controller client.
+ */
+task mapProductionRouteToActive() << {
+
+	def cfSwapDeployed = project.getTasksByName("cfSwapDeployed", false)[0]
+	def gatewayUris = [PRODUCTION_ROUTE]
+
+	cfSwapDeployed.client = null
+
+	cfSwapDeployed.withCloudFoundryClient {
+
+		def controllerClient = cfSwapDeployed.client.cc
+		List<CloudApplication> apps = cfSwapDeployed.client.applications
+
+		List<String> mappedAppVariants = cfSwapDeployed.findMappedVariants(APPLICATION_NAME, apps)
+		List<String> unmappedAppVariants = cfSwapDeployed.findUnmappedVariants(APPLICATION_NAME, apps)
+
+		if (mappedAppVariants) {
+			cfSwapDeployed.log "Mapping URIs ${gatewayUris} for ${mappedAppVariants}"
+		}
+
+		// Note: If comparing this code to the original Plugin task you'll notice
+		// these sections are switched. This is, because the production route mapping
+		// runs after cfSwitchDeployed. So at this time the inactive instance became active.
+		mappedAppVariants.each { appName ->
+			def app = controllerClient.getApplication(appName)
+			List<String> newUris = new ArrayList<String>(app.uris);
+			newUris.addAll(gatewayUris)
+			updateApplicationUris(appName, newUris, controllerClient);
+		}
+
+		if (unmappedAppVariants) {
+			cfSwapDeployed.log "Unmapping URIs ${gatewayUris} for ${unmappedAppVariants}"
+		}
+
+		unmappedAppVariants.each { appName ->
+			def app = controllerClient.getApplication(appName)
+			List<String> newUris = new ArrayList<String>(app.uris);
+			newUris.removeAll(gatewayUris)
+			updateApplicationUris(appName, newUris, controllerClient);
+		}
+	}
+}
+
+task unmapProductionRouteFromInactive << {
+
+	def cfSwapDeployed = project.getTasksByName("cfSwapDeployed", false)[0]
+	def gatewayUris = [PRODUCTION_ROUTE]
+
+	cfSwapDeployed.client = null
+
+	cfSwapDeployed.withCloudFoundryClient {
+
+		def controllerClient = cfSwapDeployed.client.cc
+		List<CloudApplication> apps = cfSwapDeployed.client.applications
+
+		List<String> unmappedAppVariants = cfSwapDeployed.findUnmappedVariants(APPLICATION_NAME, apps)
+
+		if (unmappedAppVariants) {
+			cfSwapDeployed.log "Unmapping URIs ${gatewayUris} for ${unmappedAppVariants}"
+		}
+
+		// Remove the production route from the inactive variant. Why? Well, to not
+		// let the CF plugin crash because of an unknown domain.
+		unmappedAppVariants.each { appName ->
+			def app = controllerClient.getApplication(appName)
+			List<String> newUris = new ArrayList<String>(app.uris);
+			newUris.removeAll(gatewayUris)
+			updateApplicationUris(appName, newUris, controllerClient);
+		}
+	}
+
+	cfSwapDeployed.client = null
+}
+
+
+def updateApplicationUris(String appName, List<String> uris, controllerClient) {
+	def app = controllerClient.getApplication(appName);
+	List<String> newUris = new ArrayList<String>(uris);
+	newUris.removeAll(app.getUris());
+	List<String> removeUris = app.getUris();
+	removeUris.removeAll(uris);
+
+	def sessionSpace = controllerClient.sessionSpace
+	controllerClient.sessionSpace = null
+	Map<String, UUID> domains = controllerClient.getDomainGuids();
+	controllerClient.sessionSpace = sessionSpace;
+
+	for (String uri : removeUris) {
+		Map<String, String> uriInfo = new HashMap<String, String>(2);
+		controllerClient.extractUriInfo(domains, uri, uriInfo);
+		UUID domainGuid = domains.get(uriInfo.get("domainName"));
+		controllerClient.unbindRoute(uriInfo.get("host"), domainGuid, app.getMeta().getGuid());
+	}
+
+	for (String uri : newUris) {
+		Map<String, String> uriInfo = new HashMap<String, String>(2);
+		controllerClient.extractUriInfo(domains, uri, uriInfo);
+		UUID domainGuid = domains.get(uriInfo.get("domainName"));
+		controllerClient.bindRoute(uriInfo.get("host"), domainGuid, app.getMeta().getGuid());
+	}
+}


### PR DESCRIPTION
The CF plugin uses a deprecated API to obtain domains. Our cla.pivotal.io domain is not listed there so we need a workaround which is based on a decoration of the deployment/swap tasks.
The production route is removed before the deployment from the inactive variant (precaution, to not let cfDeploy fail) and added to the active variant once cfSwapDeployed is finished.

The CF client validates domain names in the cfDeploy and cfSwapDeployed tasks and fails if the cla.pivotal.io domain is not found. Removing the space-scoping for domain retrieval does the trick but requires a lot of auxiliary code.

Fixes gh-91.
