### PR TITLE
Include logback config from Spring Boot.

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+	<include resource="org/springframework/boot/logging/logback/base.xml"/>
 	<root level="WARN"/>
 </configuration>


### PR DESCRIPTION
Include defaults provided by Spring Boot otherwise the logging configuration won't log anything as it has no appenders.
