### PR TITLE
Streamline PR comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ build/
 *.iws
 .gradle/
 atlassian-ide-plugin.xml
-src/main/resources/application-local.properties
+application-local.properties
+application-local-mysql.properties
 .factorypath
 gradle.properties
+classes/

--- a/src/main/java/io/pivotal/cla/mvc/ClaRequest.java
+++ b/src/main/java/io/pivotal/cla/mvc/ClaRequest.java
@@ -33,6 +33,7 @@ import lombok.Data;
  */
 @Data
 public class ClaRequest {
+
 	String claName;
 	String repositoryId;
 	Integer pullRequestId;
@@ -48,6 +49,7 @@ public class ClaRequest {
 		commitStatus.setSyncUrl(syncUrl());
 		commitStatus.setFaqUrl(faqUrl());
 		commitStatus.setGitHubUsername(currentUserGitHubLogin);
+		commitStatus.setPullRequestState(PullRequestStatus.UNKNOWN_PULL_REQUEST_STATE);
 
 		ClaPullRequestStatusRequest request = new ClaPullRequestStatusRequest();
 		request.setClaName(claName);

--- a/src/main/java/io/pivotal/cla/mvc/github/GitHubHooksController.java
+++ b/src/main/java/io/pivotal/cla/mvc/github/GitHubHooksController.java
@@ -79,6 +79,7 @@ public class GitHubHooksController {
 			.pullRequestId(status.getPullRequestId())
 			.build();
 		status.setUrl(signUrl);
+		status.setPullRequestState(pullRequest.getState());
 
 		ClaPullRequestStatusRequest pullRequestStatusRequest = new ClaPullRequestStatusRequest();
 		pullRequestStatusRequest.setClaName(cla);

--- a/src/main/java/io/pivotal/cla/service/github/PullRequestStatus.java
+++ b/src/main/java/io/pivotal/cla/service/github/PullRequestStatus.java
@@ -20,6 +20,10 @@ import lombok.Data;
 
 @Data
 public class PullRequestStatus {
+
+	public static final String UNKNOWN_PULL_REQUEST_STATE = "unknown";
+	public static final String OPEN_PULL_REQUEST_STATE = "open";
+
 	int pullRequestId;
 	String repoId;
 	String sha;
@@ -43,9 +47,14 @@ public class PullRequestStatus {
 	 */
 	String accessToken;
 
+	String pullRequestState;
 
 	public boolean isSuccess() {
 		return Boolean.TRUE.equals(success);
+	}
+
+	public boolean shouldInteractWithComments() {
+		return UNKNOWN_PULL_REQUEST_STATE.equals(pullRequestState) || OPEN_PULL_REQUEST_STATE.equalsIgnoreCase(pullRequestState);
 	}
 
 	/**

--- a/src/test/java/io/pivotal/cla/service/github/MylynGitHubApiITests.java
+++ b/src/test/java/io/pivotal/cla/service/github/MylynGitHubApiITests.java
@@ -385,6 +385,7 @@ public class MylynGitHubApiITests {
 		commitStatus.setSuccess(true);
 		commitStatus.setUrl("https://status.example.com/uri");
 		commitStatus.setAccessToken(accessToken);
+		commitStatus.setPullRequestState("open");
 
 		service.save(commitStatus);
 
@@ -435,6 +436,7 @@ public class MylynGitHubApiITests {
 		commitStatus.setSuccess(true);
 		commitStatus.setUrl("https://status.example.com/uri");
 		commitStatus.setAccessToken(accessToken);
+		commitStatus.setPullRequestState("open");
 
 		service.save(commitStatus);
 
@@ -486,6 +488,7 @@ public class MylynGitHubApiITests {
 		commitStatus.setSuccess(true);
 		commitStatus.setUrl("https://status.example.com/uri");
 		commitStatus.setAccessToken(accessToken);
+		commitStatus.setPullRequestState("open");
 
 		service.save(commitStatus);
 
@@ -543,6 +546,50 @@ public class MylynGitHubApiITests {
 		commitStatus.setSuccess(true);
 		commitStatus.setUrl("https://status.example.com/uri");
 		commitStatus.setAccessToken(accessToken);
+		commitStatus.setPullRequestState("open");
+
+		service.save(commitStatus);
+
+		assertThat(server.getServer().getRequestCount()).isEqualTo(3);
+
+		RecordedRequest request = server.getServer().takeRequest();
+
+		assertThat(request.getMethod()).isEqualTo("GET");
+		assertThat(request.getPath())
+				.isEqualTo("/api/v3/repos/spring-projects/spring-security/statuses/14f7eed929c0086d5d7b87d28bc4722f618a361f?per_page=100&page=1");
+		assertThat(request.getHeader("Authorization")).isEqualTo("token " + accessToken);
+
+		request = server.getServer().takeRequest();
+		assertThat(request.getMethod()).isEqualTo("GET");
+		assertThat(request.getPath())
+				.isEqualTo("/api/v3/user");
+		assertThat(request.getHeader("Authorization")).isEqualTo("token pivotal-cla-accessToken");
+
+		request = server.getServer().takeRequest();
+		assertThat(request.getMethod()).isEqualTo("GET");
+		assertThat(request.getPath())
+				.isEqualTo("/api/v3/repos/spring-projects/spring-security/issues/1/comments?per_page=100&page=1");
+		assertThat(request.getHeader("Authorization")).isEqualTo("token pivotal-cla-accessToken");
+	}
+
+	@Test
+	@EnqueueRequests({
+		"getStatusSuccess",
+		"getUserPivotalIssueMaster",
+		"getIssueCommentsNoComments",
+	})
+	public void saveSuccessDoNotAddCommentIfNoPleaseSign() throws Exception {
+		String accessToken = "access-token-123";
+
+		PullRequestStatus commitStatus = new PullRequestStatus();
+		commitStatus.setGitHubUsername("rwinch");
+		commitStatus.setPullRequestId(1);
+		commitStatus.setRepoId("spring-projects/spring-security");
+		commitStatus.setSha("14f7eed929c0086d5d7b87d28bc4722f618a361f");
+		commitStatus.setSuccess(true);
+		commitStatus.setUrl("https://status.example.com/uri");
+		commitStatus.setAccessToken(accessToken);
+		commitStatus.setPullRequestState("open");
 
 		service.save(commitStatus);
 
@@ -586,6 +633,7 @@ public class MylynGitHubApiITests {
 		commitStatus.setSuccess(true);
 		commitStatus.setUrl("https://status.example.com/uri");
 		commitStatus.setAccessToken(accessToken);
+		commitStatus.setPullRequestState("open");
 
 		service.save(commitStatus);
 
@@ -639,6 +687,7 @@ public class MylynGitHubApiITests {
 		commitStatus.setSyncUrl("https://cla.pivotal.io/sync/pivotal");
 		commitStatus.setFaqUrl("https://cla.pivotal.io/faq");
 		commitStatus.setAccessToken(accessToken);
+		commitStatus.setPullRequestState("open");
 
 		service.save(commitStatus);
 
@@ -692,6 +741,7 @@ public class MylynGitHubApiITests {
 		commitStatus.setSyncUrl("https://cla.pivotal.io/sync/pivotal");
 		commitStatus.setFaqUrl("https://cla.pivotal.io/faq");
 		commitStatus.setAccessToken(accessToken);
+		commitStatus.setPullRequestState("open");
 
 		service.save(commitStatus);
 
@@ -746,6 +796,7 @@ public class MylynGitHubApiITests {
 		commitStatus.setSyncUrl("https://cla.pivotal.io/sync/pivotal");
 		commitStatus.setFaqUrl("https://cla.pivotal.io/faq");
 		commitStatus.setAccessToken(accessToken);
+		commitStatus.setPullRequestState("open");
 
 		service.save(commitStatus);
 
@@ -787,6 +838,45 @@ public class MylynGitHubApiITests {
 				"{\"body\":\"@rwinch Please sign the [Contributor License Agreement](https://status.example.com/uri)!\\n\\n[Click here](https://cla.pivotal.io/sync/pivotal) to manually synchronize the status of this Pull Request.\\n\\nSee the [FAQ](https://cla.pivotal.io/faq) for frequently asked questions.\"}");
 	}
 
+	@Test
+	@EnqueueRequests({
+		"getStatusNone",
+		"saveStatus"
+	})
+	public void saveFailureNoCommentsPullRequestClosed() throws Exception {
+		String accessToken = "access-token-123";
+
+		PullRequestStatus commitStatus = new PullRequestStatus();
+		commitStatus.setGitHubUsername("rwinch");
+		commitStatus.setPullRequestId(1);
+		commitStatus.setRepoId("spring-projects/spring-security");
+		commitStatus.setSha("14f7eed929c0086d5d7b87d28bc4722f618a361f");
+		commitStatus.setSuccess(false);
+		commitStatus.setUrl("https://status.example.com/uri");
+		commitStatus.setSyncUrl("https://cla.pivotal.io/sync/pivotal");
+		commitStatus.setFaqUrl("https://cla.pivotal.io/faq");
+		commitStatus.setAccessToken(accessToken);
+		commitStatus.setPullRequestState("closed");
+
+		service.save(commitStatus);
+
+		assertThat(server.getServer().getRequestCount()).isEqualTo(2);
+
+		RecordedRequest request = server.getServer().takeRequest();
+		assertThat(request.getMethod()).isEqualTo("GET");
+		assertThat(request.getPath())
+				.isEqualTo("/api/v3/repos/spring-projects/spring-security/statuses/14f7eed929c0086d5d7b87d28bc4722f618a361f?per_page=100&page=1");
+		assertThat(request.getHeader("Authorization")).isEqualTo("token " + accessToken);
+
+		request = server.getServer().takeRequest();
+		assertThat(request.getMethod()).isEqualTo("POST");
+		assertThat(request.getPath())
+				.isEqualTo("/api/v3/repos/spring-projects/spring-security/statuses/14f7eed929c0086d5d7b87d28bc4722f618a361f");
+		assertThat(request.getHeader("Authorization")).isEqualTo("token " + accessToken);
+		assertThat(request.getBody().readUtf8()).isEqualTo(
+				"{\"context\":\"ci/pivotal-cla\",\"description\":\"Please sign the Contributor License Agreement!\",\"state\":\"failure\",\"target_url\":\"https://status.example.com/uri\"}");
+
+	}
 
 	@Test
 	@EnqueueRequests({
@@ -809,6 +899,7 @@ public class MylynGitHubApiITests {
 		commitStatus.setSyncUrl("https://cla.pivotal.io/sync/pivotal");
 		commitStatus.setFaqUrl("https://cla.pivotal.io/faq");
 		commitStatus.setAccessToken(accessToken);
+		commitStatus.setPullRequestState("open");
 
 		service.save(commitStatus);
 

--- a/src/test/resources/io/pivotal/cla/service/github/MylynGitHubApiITests_okhttp3/getIssueCommentsNoComments
+++ b/src/test/resources/io/pivotal/cla/service/github/MylynGitHubApiITests_okhttp3/getIssueCommentsNoComments
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+X-RateLimit-Limit: 5000
+X-RateLimit-Remaining: 4999
+
+[
+]


### PR DESCRIPTION
Add comments only if the Pull-request is open and:
1. If the user hasn't signed the CLA at all
2. If the user signed the CLA and the system added a comment like "Please sign..."

Make also sure the "Please sign" and "Thank you" comments occur only once.
