### PR TITLE
Fix null sync and FAQ URL

### DIFF
--- a/src/main/java/io/pivotal/cla/mvc/ClaRequest.java
+++ b/src/main/java/io/pivotal/cla/mvc/ClaRequest.java
@@ -71,23 +71,13 @@ public class ClaRequest {
 	private String syncUrl() throws Exception {
 		ServletRequestAttributes requestAttributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
 		HttpServletRequest request = requestAttributes.getRequest();
-
-		String urlEncodedClaName = URLEncoder.encode(claName, "UTF-8");
-		UrlBuilder url = UrlBuilder
-				.fromRequest(request)
-				.path("/sync/"+urlEncodedClaName)
-				.param("repositoryId", repositoryId)
-				.param("pullRequestId", String.valueOf(pullRequestId));
-		return url.build();
+		return UrlBuilder.createSyncUrl(request, claName, repositoryId, pullRequestId);
 	}
 
 	private String faqUrl() throws Exception {
 		ServletRequestAttributes requestAttributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
 		HttpServletRequest request = requestAttributes.getRequest();
 
-		UrlBuilder url = UrlBuilder
-				.fromRequest(request)
-				.path("/faq");
-		return url.build();
+		return UrlBuilder.createFaqUrl(request);
 	}
 }

--- a/src/main/java/io/pivotal/cla/mvc/github/GitHubHooksController.java
+++ b/src/main/java/io/pivotal/cla/mvc/github/GitHubHooksController.java
@@ -80,6 +80,12 @@ public class GitHubHooksController {
 			.build();
 		status.setUrl(signUrl);
 
+		String syncUrl = UrlBuilder.createSyncUrl(request, cla, status.getRepoId(), status.getPullRequestId());
+		status.setSyncUrl(syncUrl);
+
+		String faqUrl = UrlBuilder.createFaqUrl(request);
+		status.setFaqUrl(faqUrl);
+
 		ClaPullRequestStatusRequest pullRequestStatusRequest = new ClaPullRequestStatusRequest();
 		pullRequestStatusRequest.setClaName(cla);
 		pullRequestStatusRequest.setCommitStatus(status);

--- a/src/main/java/io/pivotal/cla/mvc/util/UrlBuilder.java
+++ b/src/main/java/io/pivotal/cla/mvc/util/UrlBuilder.java
@@ -29,7 +29,6 @@ import lombok.SneakyThrows;
 
 /**
  * @author Rob Winch
- *
  */
 public class UrlBuilder {
 
@@ -58,25 +57,46 @@ public class UrlBuilder {
 		return this;
 	}
 
-	@Builder(builderMethodName="signUrl")
+	@Builder(builderMethodName = "signUrl")
 	@SneakyThrows
-	private static String create(HttpServletRequest request, String claName, String repositoryId, int pullRequestId) {
+	private static String createSignUrl(HttpServletRequest request, String claName, String repositoryId,
+			int pullRequestId) {
 		String urlEncodedClaName = URLEncoder.encode(claName, "UTF-8");
-		UrlBuilder url = UrlBuilder
-				.fromRequest(request)
-				.path("/sign/"+urlEncodedClaName)
-				.param("repositoryId", repositoryId)
+		UrlBuilder url = UrlBuilder //
+				.fromRequest(request) //
+				.path("/sign/" + urlEncodedClaName) //
+				.param("repositoryId", repositoryId) //
 				.param("pullRequestId", String.valueOf(pullRequestId));
 		return url.build();
 	}
 
+	@SneakyThrows
+	public static String createSyncUrl(HttpServletRequest request, String claName, String repositoryId,
+			int pullRequestId) {
+		String urlEncodedClaName = URLEncoder.encode(claName, "UTF-8");
+		UrlBuilder url = UrlBuilder //
+				.fromRequest(request) //
+				.path("/sync/" + urlEncodedClaName) //
+				.param("repositoryId", repositoryId) //
+				.param("pullRequestId", String.valueOf(pullRequestId));
+		return url.build();
+	}
+
+	@SneakyThrows
+	public static String createFaqUrl(HttpServletRequest request) {
+		UrlBuilder url = UrlBuilder //
+				.fromRequest(request)//
+				.path("/faq");//
+		return url.build();
+	}
+
 	public String build() {
-		String url = UriComponentsBuilder
-				.fromHttpRequest(new ServletServerHttpRequest(request))
-				.replacePath(path)
-				.replaceQueryParams(params)
-				.build()
-				.toUriString();
+		String url = UriComponentsBuilder //
+				.fromHttpRequest(new ServletServerHttpRequest(request))//
+				.replacePath(path) //
+				.replaceQueryParams(params) //
+				.build() //
+				.toUriString(); //
 
 		this.path = null;
 		this.params.clear();

--- a/src/test/java/io/pivotal/cla/mvc/github/GitHubHooksControllerTests.java
+++ b/src/test/java/io/pivotal/cla/mvc/github/GitHubHooksControllerTests.java
@@ -90,6 +90,8 @@ public class GitHubHooksControllerTests extends BaseWebDriverTests {
 		assertThat(status.getPullRequestId()).isEqualTo(2);
 		assertThat(status.getSha()).isEqualTo("a6befb598a35c1c206e1bf7bbb3018f4403b9610");
 		assertThat(status.getUrl()).isEqualTo("http://localhost/sign/pivotal?repositoryId=rwinch/176_test&pullRequestId=2");
+		assertThat(status.getFaqUrl()).endsWith("/faq");
+		assertThat(status.getSyncUrl()).contains("/sync/pivotal?repositoryId=rwinch/176_test&pullRequestId=2");
 		assertThat(status.isSuccess()).isFalse();
 	}
 


### PR DESCRIPTION
The sync and FAQ URLs are now provided with values. Aligned usage in code to use the same factory for URLs.

Fixes gh-112
