### PR TITLE
Format links using AsciiDoc in .adoc file

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -36,7 +36,7 @@ security.oauth2.main.clientSecret=Value from Client Secret
 
 == Register a personal access token
 
-* Generate a [New personal access token](https://github.com/settings/tokens/new) that contains only `public_repo` scope.
+* Generate a https://github.com/settings/tokens/new[New personal access token] that contains only `public_repo` scope.
 This will be used for adding comments to pull requests that require the contributor to sign the CLA.
 * Copy the personal access token and place it in application-local.properties
 
@@ -78,7 +78,7 @@ If you are running, the default URL is at http://localhost:8080/
 
 == Cloud Foundry
 
-Deploying the application to Cloud Foundry can be performed as part of the build using the [Cloud Foundry Gradle plugin](http://docs.run.pivotal.io/buildpacks/java/build-tool-int.html#gradle).
+Deploying the application to Cloud Foundry can be performed as part of the build using the http://docs.run.pivotal.io/buildpacks/java/build-tool-int.html#gradle[Cloud Foundry Gradle plugin].
 It's set up for TravisCI and manual deployment mode.
 
 === Required Properties
@@ -94,7 +94,7 @@ Deployment scripts for `pivotal-cla` require a set of properties to be deployed.
 
 === Variants (aka. Blue/Green-Deployment)
 
-Production and Staging have blue/green deployment set up. That's done by setting the `variants` property of the [Cloud Foundry Gradle plugin](http://docs.run.pivotal.io/buildpacks/java/build-tool-int.html#gradle).
+Production and Staging have blue/green deployment set up. That's done by setting the `variants` property of the http://docs.run.pivotal.io/buildpacks/java/build-tool-int.html#gradle[Cloud Foundry Gradle plugin].
 Setting `variants` causes `cfDeploy` to check which variant is active and deploy to the inactive variant. The deployment
 task switches blue/green instances using `cfSwapDeployed` once the application is deployed and started.
 


### PR DESCRIPTION
Some links in the `README.adoc` file were formatted using Markdown link syntax, [title](url), rather than AsciiDoc syntax, url[title].
