### PR TITLE
Wrap the ICLA and CCLA text and buttons in a panel

### DIFF
--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -30,25 +30,33 @@
 		<div class="alert alert-info" role="alert">
 			If you are submitting an <a th:href="@{/about#obvious-fixes}">obvious fix</a>, then you do not need to sign the CLA.
 		</div>
-		<div class="container">
-			<div class="row">
-				<div class="col-md-6">
-					<h2>Individual Contributor License Agreement</h2>
-					<p>
-						I'm an individual contributor
-					</p>
-					<p>
-						<a id="icla-link" class="btn btn-success btn-lg" th:href="${pullRequestId == null} ? @{/sign/{claName}/icla(claName=${claName})} : @{/sign/{claName}/icla(claName=${claName},repositoryId=${repositoryId},pullRequestId=${pullRequestId})}">Sign Individual CLA</a>
-					</p>
+		<div class="col-md-6">
+			<div class="panel panel-default">
+				<div class="panel-heading">
+					<h2 class="panel-title">
+						Individual Contributor License Agreement
+					</h2>
 				</div>
-				<div class="col-md-6">
-					<h2>Corporate Contributor License Agreement</h2>
-					<p>
-						I'm representing a company wanting its employees to contribute
-					</p>
-					<p>
-						<a id="ccla-link" class="btn btn-success btn-lg" th:href="${pullRequestId == null} ? @{/sign/{claName}/ccla(claName=${claName})} : @{/sign/{claName}/ccla(claName=${claName},repositoryId=${repositoryId},pullRequestId=${pullRequestId})}">Sign Corporate CLA</a>
-					</p>
+				<p class="panel-body">
+					I'm an individual contributor
+				</p>
+				<div class="panel-footer">
+					<a id="icla-link" class="btn btn-success btn-lg" th:href="${pullRequestId == null} ? @{/sign/{claName}/icla(claName=${claName})} : @{/sign/{claName}/icla(claName=${claName},repositoryId=${repositoryId},pullRequestId=${pullRequestId})}">Sign Individual CLA</a>
+				</div>
+			</div>
+		</div>
+		<div class="col-md-6">
+			<div class="panel panel-default">
+				<div class="panel-heading">
+					<h2 class="panel-title">
+						Corporate Contributor License Agreement
+					</h2>
+				</div>
+				<p class="panel-body">
+					I'm representing a company wanting its employees to contribute
+				</p>
+				<div class="panel-footer">
+					<a id="ccla-link" class="btn btn-success btn-lg" th:href="${pullRequestId == null} ? @{/sign/{claName}/ccla(claName=${claName})} : @{/sign/{claName}/ccla(claName=${claName},repositoryId=${repositoryId},pullRequestId=${pullRequestId})}">Sign Corporate CLA</a>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
This makes both fit better at all sizes.

Since this is the landing page (most of the time) it should be obvious which buttons are for which part of the text.

I get it might be individual taste, but I like that the panels now draw individual attention, and that they are both bordered in such a way that you can see where the first one ends and the other begins.
Also, I quite like that both the pieces of text are now equally long, and break in the same way.

| screen size (bootstrap) |  before                                  | after                                     |
|--------------------------|--------------------------------|-------------------------------|
| large                             | ![image][large_before]          | ![image][large_after]            |
| medium                        | ![image][medium_before]     | ![image][medium_after]      |
| small                             | ![image][small_before]          | ![image][small_after]           |
| extra small                    | ![image][extra_small_before] | ![image][extra_small_after] |



[large_before]: https://cloud.githubusercontent.com/assets/4105066/24254668/c50a86fa-0fe3-11e7-8b6a-ccb4b848ec2a.png
[large_after]: https://cloud.githubusercontent.com/assets/4105066/24254614/aa2351c8-0fe3-11e7-9397-87e2803cc2dd.png

[medium_before]: https://cloud.githubusercontent.com/assets/4105066/24255019/a7088106-0fe4-11e7-83eb-dfdd26147335.png
[medium_after]: https://cloud.githubusercontent.com/assets/4105066/24255094/d4a65cfa-0fe4-11e7-8f99-44fcdde8f31e.png

[small_before]: https://cloud.githubusercontent.com/assets/4105066/24255241/341be84e-0fe5-11e7-90ff-fedcc0fabf2d.png
[small_after]: https://cloud.githubusercontent.com/assets/4105066/24255270/4e53aa58-0fe5-11e7-9746-698c722c0279.png

[extra_small_before]: https://cloud.githubusercontent.com/assets/4105066/24255461/e09634d0-0fe5-11e7-918d-a0be4139a831.png
[extra_small_after]: https://cloud.githubusercontent.com/assets/4105066/24255489/f643d2ec-0fe5-11e7-9290-6dfc05a9a091.png