### PR TITLE
Allow GitHub Actions Bot

### DIFF
--- a/src/main/java/io/pivotal/cla/service/github/MylynGitHubApi.java
+++ b/src/main/java/io/pivotal/cla/service/github/MylynGitHubApi.java
@@ -64,7 +64,7 @@ import io.pivotal.cla.service.MigratePullRequestStatusRequest;
 @Component
 public class MylynGitHubApi implements GitHubApi {
 	private static final Set<String> ALLOWED_BOTS = new HashSet<>(Arrays.asList("dependabot-preview", "dependabot-preview[bot]",
-			"dependabot", "dependabot[bot]"));
+			"dependabot", "dependabot[bot]", "github-actions[bot]"));
 	private static final String AUTHORIZE_URI = "login/oauth/access_token";
 	public static final String CONTRIBUTING_FILE = "CONTRIBUTING";
 	public static final String ADMIN_MAIL_SUFFIX = "@pivotal.io";


### PR DESCRIPTION
This change adds the GitHub Actions bot (the identity in a GitHub action's $GITHUB_TOKEN) to the list of allowed bots.  As more teams move over to GitHub Actions, passing CLA will require this. 

see: https://github.com/projectriff/builder/pull/395