### PR TITLE
All riff Bot

### DIFF
--- a/src/main/java/io/pivotal/cla/service/github/MylynGitHubApi.java
+++ b/src/main/java/io/pivotal/cla/service/github/MylynGitHubApi.java
@@ -64,7 +64,7 @@ import io.pivotal.cla.service.MigratePullRequestStatusRequest;
 @Component
 public class MylynGitHubApi implements GitHubApi {
 	private static final Set<String> ALLOWED_BOTS = new HashSet<>(Arrays.asList("dependabot-preview", "dependabot-preview[bot]",
-			"dependabot", "dependabot[bot]", "github-actions[bot]"));
+			"dependabot", "dependabot[bot]", "github-actions[bot]", "pfs-ci-gitbot"));
 	private static final String AUTHORIZE_URI = "login/oauth/access_token";
 	public static final String CONTRIBUTING_FILE = "CONTRIBUTING";
 	public static final String ADMIN_MAIL_SUFFIX = "@pivotal.io";


### PR DESCRIPTION
This change adds the riff (formerly PFS) bot to the list of allowed bots.
